### PR TITLE
Migrate gradle repository from jcenter to mavencentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
JCenter having an issue today and expected can have a future issue as well. To prevent failing build , this PR migrate jcenter to mavenCentral.