### PR TITLE
Update Android build config, compileSDK, AGP and Gradle versions

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,8 +22,6 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
-  enable-experiment:
-    - extension-methods
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 
@@ -22,12 +22,15 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    namespace 'com.ajinasokan.flutterdisplaymode'
+
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.ajinasokan.flutterdisplaymode">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/android/src/main/java/com/ajinasokan/flutterdisplaymode/DisplayModePlugin.java
+++ b/android/src/main/java/com/ajinasokan/flutterdisplaymode/DisplayModePlugin.java
@@ -40,7 +40,7 @@ public class DisplayModePlugin implements FlutterPlugin, MethodCallHandler, Acti
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            result.error("noAPI", "API is supported only in Marshmallow and later", null);
+            result.error("noAPI", "API is supported only in Android 6 (Marshmallow) and later", null);
             return;
         }
 
@@ -80,7 +80,7 @@ public class DisplayModePlugin implements FlutterPlugin, MethodCallHandler, Acti
 
     @RequiresApi(api = Build.VERSION_CODES.M)
     private void getActiveMode(@NonNull Result result) {
-        final Display.Mode mode =  getDisplay().getMode();
+        final Display.Mode mode = getDisplay().getMode();
         final HashMap<String, Object> ret = new HashMap<>();
         ret.put("id", mode.getModeId());
         ret.put("width", mode.getPhysicalWidth());
@@ -121,7 +121,7 @@ public class DisplayModePlugin implements FlutterPlugin, MethodCallHandler, Acti
 
         // look for matching mode and return it
         for (final Display.Mode mode : modes) {
-            if(params.preferredDisplayModeId == mode.getModeId()) {
+            if (params.preferredDisplayModeId == mode.getModeId()) {
                 final HashMap<String, Object> item = new HashMap<>();
                 item.put("id", mode.getModeId());
                 item.put("width", mode.getPhysicalWidth());

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -29,9 +29,11 @@ android {
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+
+    namespace 'com.ajinasokan.example'
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ajinasokan.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ajinasokan.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="example"
         android:name="${applicationName}"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Thu Apr 20 15:34:06 EEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    SchedulerBinding.instance!.addPostFrameCallback((_) {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
       fetchAll();
     });
   }
@@ -77,7 +77,7 @@ class _MyAppState extends State<MyApp> {
                     children: <Widget>[
                       Text(
                         'Available modes',
-                        style: Theme.of(context).textTheme.headline5,
+                        style: Theme.of(context).textTheme.headlineSmall,
                       ),
                       TextButton.icon(
                         icon: const Icon(Icons.refresh),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,10 +9,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This PR updates the build config and does some other minor updates to modernise the setup.

The reason for that is that `3.5.0` of Android Gradle plugin (AGP) is really old as of today and soon there might be issues with building the project, like it currently is if some project tries to use latest Kotlin versions with some 3.x AGP.

~~Initially I wanted to update the project to use the latest Android Gradle plugin 8 and Gradle wrapper 8, but at the moment there are some issues with project sync on the latest stable Flutter (3.7.11). Thus, I moved to the latest versions before.~~
UPD: With `3.7.12` release of Flutter I could update to Gradle 8 as it is mentioned in release notes: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel#3712-apr-19-2023

Changes:
- Bumped AGP version to 8.0.0 for both the plugin and example app.
- Updated Gradle wrapper version to 8.0.2 for both the plugin and example app.
- Bumped compileSDK to 33.
- Added `namespace` property to build.gradle files for compatibility with Gradle 8.
- Bumped Java to 17 in compile options to use the latest tooling and compatibility with Gradle 8.
- Dropped `enableJetifier` as project uses no support libraries and this property slows down builds.
- Did minor code cleanup with removing some deprecated properties and formatting.

P.S. Thanks for this useful package.